### PR TITLE
patching sagan negative ip check

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -213,7 +213,7 @@ void Load_Rules( const char *ruleset )
     uint8_t d=0;
 
     int rc=0;
-    
+
     uint_fast8_t z = 0;
 
     uint32_t forward=0;
@@ -629,7 +629,7 @@ void Load_Rules( const char *ruleset )
 
                                             f1++;
 
-                                            is_masked = Netaddr_To_Range(tmptoken, (unsigned char *)&rulestruct[counters->rulecount].flow_1[flow_1_count].range);
+                                            is_masked = Netaddr_To_Range(tok_help, (unsigned char *)&rulestruct[counters->rulecount].flow_1[flow_1_count].range);
 
                                             if(strchr(tmptoken, '/'))
                                                 {
@@ -815,7 +815,7 @@ void Load_Rules( const char *ruleset )
 
                                             f2++;
 
-                                            is_masked = Netaddr_To_Range(tmptoken, (unsigned char *)&rulestruct[counters->rulecount].flow_2[flow_2_count].range);
+                                            is_masked = Netaddr_To_Range(tok_help, (unsigned char *)&rulestruct[counters->rulecount].flow_2[flow_2_count].range);
 
                                             if(strchr(tmptoken, '/'))
                                                 {


### PR DESCRIPTION
Closes: https://github.com/ccxtechnologies/builder/issues/5213

**Problem**: 
Adding a Sagan rule with a negated IP check, for example, 
`alert any !127.0.0.1 any -> $HOME_NET any (msg: "TEST alert 3";  content: "test message"; classtype: system-event; sid: 9000502; rev: 1;)` 
will not function as expected, for example, without changing the configuration to account for the src_ip (see [here]([https://github.com/ccxtechnologies/builder/issues/5191#:~:text=so%20something%20like%3A-,%22src_ip%22%3A%22.SOURCEIP%22,-wbilal%2Dc%20commented](https://github.com/ccxtechnologies/builder/issues/5191#:~:text=so%20something%20like:-,%22src_ip%22:%22.SOURCEIP%22,-wbilal-c%20commented))), the rule will pass on every attempt whether it is coming from a local or non-local IP address. The expected behaviour is that the local message does not trigger an alert, and a non-local message does trigger an alert based on this rule. 

More on why negative check doesn't work: see [here](https://github.com/ccxtechnologies/builder/issues/5191#:~:text=%2D%3E%20actually%20this%20makes,attempt%20to%20trigger)

**Analysis**: 
Confirmed that the IP address associated with the negative IP address from the rule above, `ipbits`, is not set. `ipbits` is supposed to be set in the `Netaddr_To_Range` function (see [here](https://github.com/ccxtechnologies/builder/issues/5191#issuecomment-3090531557)). From examining the functionality `Netaddr_To_Range`  [here](https://github.com/ccxtechnologies/builder/issues/5191#issuecomment-3090531557), I confirmed that the function is not expecting an IP address which includes the negation character, `!`, in front of it, the negation is accounted for [elsewhere]([https://github.com/ccxtechnologies/builder/issues/5191#:~:text=I%20know%20that%20the%20negative%20check%20in%20the%20flow%20variable%20is%20in%20general%20accounted%20for%20in%20the%20Check_Flow%20function%20with%20the%20the%20flow_type%3A%20https%3A//github.com/quadrantsec/sagan/blob/main/src/flow.c%23L155](https://github.com/ccxtechnologies/builder/issues/5191#:~:text=I%20know%20that%20the%20negative%20check%20in%20the%20flow%20variable%20is%20in%20general%20accounted%20for%20in%20the%20Check_Flow%20function%20with%20the%20the%20flow_type:%20https://github.com/quadrantsec/sagan/blob/main/src/flow.c#L155)), in the `flow_type`. 

But the calls to `Netaddr_To_Range` pass in as the argument for the ip address, `tmptoken`, which **does** include the negation character `!`: https://github.com/quadrantsec/sagan/blob/main/src/rules.c#L632
```
is_masked = Netaddr_To_Range(tmptoken, (unsigned char *)&rulestruct[counters->rulecount].flow_1[flow_1_count].range);
```

See here for full analysis: https://github.com/ccxtechnologies/builder/issues/5191#issuecomment-3090531557

**Solution**: There is already a variable storing the IP address that has the [negation character stripped](https://github.com/quadrantsec/sagan/blob/main/src/rules.c#L623), `tok_help`, but what's passed to `Netaddr_To_Range` is `tmptoken`, which contains extra characters that result in the IP address not being set.
The solution for this is then to replace the variables going into this function with the stripped IP address, so replace the argument `tmptoken` with `tok_help`.

