### PR TITLE
Fixing stripchars

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -286,8 +286,6 @@ void Load_Rules( const char *ruleset )
 
             memset(netstr, 0, sizeof(netstr));
             memset(rulestr, 0, sizeof(rulestr));
-            memset(tok_help, 0, 64);
-            memset(tok_help2, 0, 64);
 
             int f1=0; /* Need for flow_direction, must reset every rule, not every group */
             int f2=0; /* Need for flow_direction, must reset every rule, not every group */

--- a/src/rules.c
+++ b/src/rules.c
@@ -286,6 +286,8 @@ void Load_Rules( const char *ruleset )
 
             memset(netstr, 0, sizeof(netstr));
             memset(rulestr, 0, sizeof(rulestr));
+            memset(tok_help, 0, 64);
+            memset(tok_help2, 0, 64);
 
             int f1=0; /* Need for flow_direction, must reset every rule, not every group */
             int f2=0; /* Need for flow_direction, must reset every rule, not every group */

--- a/src/util.c
+++ b/src/util.c
@@ -1182,29 +1182,24 @@ bool Starts_With(const char *str, const char *prefix)
     return lenstr < lenpre ? false : strncmp(prefix, str, lenpre) == 0;
 }
 
-/**********************************/
-/* Strip characters from a string */
-/**********************************/
+/***************************************************/
+/* Strip characters from the beginning of a string */
+/***************************************************/
 
 void Strip_Chars(const char* string, const char *chars, char *str)
 {
 
     uint_fast32_t i = 0;
-    uint_fast32_t offset = 0;
+    uint_fast32_t out_index = 0;
 
     for( i = 0; i < strlen(string); i++)
     {
-        if (!strchr(chars, *(string+i)))
-        {
-            // the ith char is not in chars, so we copy it
-            memcpy(str,string+offset, strlen(string)-offset);
-            str[strlen(str)] = '\0';
-            break;
-        }
-        else
-        {
-            offset++;
-        }
+       if (strchr(chars, string[i]) == NULL) 
+       {
+           str[out_index] = string[i];
+           str[out_index+1]='\0';
+           out_index++;
+       }       
     }
 
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1188,25 +1188,25 @@ bool Starts_With(const char *str, const char *prefix)
 
 void Strip_Chars(const char *string, const char *chars, char *str)
 {
-
-    uint_fast32_t i = 0;
-    uint_fast32_t index = 0;
-    uint_fast32_t found_index = 0;
-
-    for( i = 0; i < strlen(string); i++)
+    if (string == NULL || chars == NULL || str == NULL) 
     {
-       if (strchr(chars, string[i]) == NULL && !(found_index)) 
-       {
-           found_index = 1;
-       }
-       if (found_index)
-       {   
-           str[index] = string[i];
-           str[index+1] = '\0';
-           index++;  
-       }
- 
+        
+        if (str != NULL) 
+            str[0] = '\0';
+        return;
+        
     }
+    
+    const char* start = string; 
+    
+    while (*start != '\0' && strchr(chars, *start) != NULL)
+    {
+        start++;
+    }
+
+    uint_fast32_t length = strlen(start);
+    strcpy(str, start);
+    str[length] = '\0';
 
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1186,7 +1186,7 @@ bool Starts_With(const char *str, const char *prefix)
 /* Strip characters from the beginning of a string */
 /***************************************************/
 
-void Strip_Chars(const char* string, const char *chars, char *str)
+void Strip_Chars(const char *string, const char *chars, char *str)
 {
 
     uint_fast32_t i = 0;

--- a/src/util.c
+++ b/src/util.c
@@ -1190,15 +1190,15 @@ void Strip_Chars(const char *string, const char *chars, char *str)
 {
 
     uint_fast32_t i = 0;
-    uint_fast32_t out_index = 0;
+    uint_fast32_t index = 0;
 
     for( i = 0; i < strlen(string); i++)
     {
        if (strchr(chars, string[i]) == NULL) 
        {
-           str[out_index] = string[i];
-           str[out_index+1]='\0';
-           out_index++;
+           str[index] = string[i];
+           str[index+1] = '\0';
+           index++;
        }       
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1191,15 +1191,21 @@ void Strip_Chars(const char *string, const char *chars, char *str)
 
     uint_fast32_t i = 0;
     uint_fast32_t index = 0;
+    uint_fast32_t found_index = 0;
 
     for( i = 0; i < strlen(string); i++)
     {
-       if (strchr(chars, string[i]) == NULL) 
+       if (strchr(chars, string[i]) == NULL && !(found_index)) 
        {
+           found_index = 1;
+       }
+       if (found_index)
+       {   
            str[index] = string[i];
            str[index+1] = '\0';
-           index++;
-       }       
+           index++;  
+       }
+ 
     }
 
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1186,22 +1186,23 @@ bool Starts_With(const char *str, const char *prefix)
 /* Strip characters from a string */
 /**********************************/
 
-void Strip_Chars(const char *string, const char *chars, char *str)
-{
+void Strip_Chars(const char* string, const char *chars, char *str){
 
     uint_fast32_t i = 0;
-
-    for ( i = 0; i<strlen(string); i++)
-        {
-
-            if (!strchr(chars, *string))
-                {
-                    str[i] = string[i];
-                    str[i+1] = '\0';
-                }
-
+    uint_fast32_t offset = 0;
+    
+    for( i = 0; i < strlen(string); i++){
+        if (!strchr(chars, *(string+i))){
+            // the ith char is not in chars, so we copy it
+            memcpy(str,string+offset, strlen(string)-offset);
+            str[strlen(str)] = '\0';
+            break;
         }
-
+        else{    
+            offset++;
+        }
+    } 
+    
 }
 
 /***************************************************

--- a/src/util.c
+++ b/src/util.c
@@ -1186,23 +1186,27 @@ bool Starts_With(const char *str, const char *prefix)
 /* Strip characters from a string */
 /**********************************/
 
-void Strip_Chars(const char* string, const char *chars, char *str){
+void Strip_Chars(const char* string, const char *chars, char *str)
+{
 
     uint_fast32_t i = 0;
     uint_fast32_t offset = 0;
-    
-    for( i = 0; i < strlen(string); i++){
-        if (!strchr(chars, *(string+i))){
+
+    for( i = 0; i < strlen(string); i++)
+    {
+        if (!strchr(chars, *(string+i)))
+        {
             // the ith char is not in chars, so we copy it
             memcpy(str,string+offset, strlen(string)-offset);
             str[strlen(str)] = '\0';
             break;
         }
-        else{    
+        else
+        {
             offset++;
         }
-    } 
-    
+    }
+
 }
 
 /***************************************************

--- a/src/util.c
+++ b/src/util.c
@@ -1204,9 +1204,9 @@ void Strip_Chars(const char *string, const char *chars, char *str)
         start++;
     }
 
-    uint_fast32_t length = strlen(start);
-    strcpy(str, start);
-    str[length] = '\0';
+    uint_fast32_t bytes_to_copy = strlen(start);
+    strncpy(str, start, bytes_to_copy);
+    str[bytes_to_copy] = '\0';
 
 }
 


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/5266

**Problem**: Sagan web attack rules which filter out local messages with a negative IP check were giving inconsistent results in the actual web-attack.rules file and my smaller set of test rules. Sometimes, the rules would work as expected (local message wouldn't trigger an alert, non-local would) and other times, the rule did not work as expected (local and non-local messages triggered alerts), and this was only the case in the actual web-attack rules and not my test set. 

**Analysis**: 
My test rules were different in the following way that was significant: 
- they contained a positive IP check rule ie, `alert any 127.0.0.1 ....` 
- this rule was before the negative check rule
- the actual web attack rules only contained negative IP check rules, ie, `alert any !127.0.0.1 ....`

So my test rules were masking a problem with Sagan's `Strip_chars` function and assuming that the IP address was reset on every rule, my test rules were actually relying on the Strip_chars function working

Problem with `Strip_Chars`: 
- it *only* created a new IP address if there was no negative characters to be stripped
  - so in the case of my positive check rule, it was able to create an IP address
  - this IP address stayed persistent for the negative IP check rules because it was never reset

**Solution**: 
- `Strip_Chars` should properly strip the negative characters and always create a new IP address
- `tok_help` should be reset
- `tok_help2` behaves similarly to `tok_help` but for the port instead of the IP address, and that should also be reset 