### PR TITLE
resetting tok_help

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -286,6 +286,7 @@ void Load_Rules( const char *ruleset )
 
             memset(netstr, 0, sizeof(netstr));
             memset(rulestr, 0, sizeof(rulestr));
+            memset(tok_help, 0, sizeof(tok_help));
 
             int f1=0; /* Need for flow_direction, must reset every rule, not every group */
             int f2=0; /* Need for flow_direction, must reset every rule, not every group */


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/5266

Problem and Root Cause:

`tok_help` is the variable used to keep track of the IP address associated with a rule (established [here](https://github.com/ccxtechnologies/sagan/pull/3#issuecomment-3282421926) )
It should be reset per rule, it is only initialised once outside of the loop. 
tok_help initialized here outside of the loop to check rules: https://github.com/ccxtechnologies/sagan/blob/0d224ba69292237f79468ffbaf50bfddb4c9001a/src/rules.c#L150

beginning of loop where rules are checked: https://github.com/ccxtechnologies/sagan/blob/0d224ba69292237f79468ffbaf50bfddb4c9001a/src/rules.c#L265

Solution: 

reset `tok_help` on a new rule

Designs considered: https://github.com/ccxtechnologies/builder/issues/5266#issuecomment-3324389519

Implementations considered: 
- https://github.com/ccxtechnologies/builder/issues/5266#issuecomment-3324541427
- https://github.com/ccxtechnologies/builder/issues/5266#issuecomment-3324634242

Testing that the problem is fixed: https://github.com/ccxtechnologies/builder/issues/5266#issuecomment-3324728182




